### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+sudo: false
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-5
+      - libboost1.55-dev
+      - libboost-test1.55-dev
+      - libgmp3-dev
+env:
+  - COMPILER=g++-5
+before_script:
+  - $COMPILER --version
+  - CXX=$COMPILER cmake .
+script:
+  - CXX=$COMPILER make
+after_success:
+  - ./test/runtest


### PR DESCRIPTION
Travis CI documentation: https://docs.travis-ci.com/
Travis build/test job corresponding to this PR: https://travis-ci.org/virtualtam/rsa/builds/98226794

Steps:
- add Boost and Ubuntu Toolchain PPAs
- install recent packages (i.e. with decent C++11 support)
- pre-build:    cmake
- build:        make
- post-build:   runtest
- profit ;-)

Resources:
- https://docs.travis-ci.com/user/languages/cpp/
- https://docs.travis-ci.com/user/apt/
- https://docs.travis-ci.com/user/environment-variables/
- https://jonasw.de/blog/2015/07/22/develop/cplusplus14-on-travis-with-cmake/
- http://stackoverflow.com/questions/29312015/building-with-more-than-one-version-of-a-compiler
